### PR TITLE
Pattern matching fails when player rack does not contain letter but does contain wildcard

### DIFF
--- a/app/src/main/java/com/example/james/ultimatewordfinderr/PatternMatcher.java
+++ b/app/src/main/java/com/example/james/ultimatewordfinderr/PatternMatcher.java
@@ -164,6 +164,12 @@ public class PatternMatcher {
                                         }
                                     }
                                 }
+                            } else {
+                                if(playerLetterMap.containsKey("?")){
+                                    if(playerLetterMap.get("?") > 0){
+                                        playerLetterMap.put("?", playerLetterMap.get("?") - 1);
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fix case where player rack does not contain letter, but does contain wildcard